### PR TITLE
Fix issue with DropletUtils::read10xCount function in R

### DIFF
--- a/pegasusio/hdf5_utils.py
+++ b/pegasusio/hdf5_utils.py
@@ -427,7 +427,9 @@ def write_10x_h5(data: MultimodalData, output_file: str) -> None:
                 shuffle=True,
             )
             grp.create_dataset(
-                name="shape", data=(n_feature, n_obs)
+                name="shape",
+                dtype=np.int32,
+                data=(n_feature, n_obs),
             )  # feature-by-barcode
 
             feature_grp = grp.create_group("features")


### PR DESCRIPTION
## Issue

```
> sce <- read10xCounts("Velocyto.spliced.h5", type="HDF5", version="3")
Error: BiocParallel errors
  1 remote errors, element index: 1
  0 unevaluated and other errors
  first remote error: invalid class “CSC_H5SparseMatrixSeed” object: invalid object for slot "dim" in class "CSC_H5SparseMatrixSeed": got class "numeric", should be or extend class "integer"
```
## Solution

Explicitly convert `matrix/shape` into 32-bit integer type, rather than the default 64-bit integer type. As otherwise, R will convert it into `numeric` type, which conflicts with `read10xCounts` assertion.