### PR TITLE
Don't raise exception if only one count matrix exists

### DIFF
--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -127,10 +127,11 @@ class UnimodalData:
         if len(self.matrices) == 0:
             self._cur_matrix = ""
         else:
-            if cur_matrix == None:
+            if cur_matrix == None or len(list(self.matrices.keys())) == 1:
                 cur_matrix = list(self.matrices.keys())[0]
             elif cur_matrix not in self.matrices.keys():
                 raise ValueError("Cannot find the default count matrix to bind to. Please set 'cur_matrix' argument in UnimodalData constructor!")
+
             self._cur_matrix = cur_matrix # cur_matrix
 
         # For backword compatibility, check metadata and move arrays and graphs to multiarrays/multigraphs


### PR DESCRIPTION
This is for backward compatibility.

Although the default name of raw count matrix has been changed from `raw.count` or `X` to `counts`, we still want to make the data generated by old versions of PegasusIO can still be loaded.

The `rna` modality doesn't have this issue, because it by default sets `None` for `cur_matrix`. But for other modalities, since they have default key names, it restricts the loading.

For example, Souporcell workflow uses PegasusIO v0.2.10, which is the last version supporting Python 3.6, to generate results.