### PR TITLE
UnimodalDataView.copy() returns MultimodalData by default

### DIFF
--- a/pegasusio/spatial_utils.py
+++ b/pegasusio/spatial_utils.py
@@ -103,7 +103,10 @@ def load_visium_folder(input_path) -> MultimodalData:
                 scale_factors[f"tissue_{res_tag}_scalef"],
                 scale_factors["spot_diameter_fullres"],
             )
-            image_metadata = pd.concat([image_metadata, image_item], ignore_index=True)
+            image_metadata = pd.concat(
+                [image_metadata if not image_metadata.empty else None, image_item],
+                ignore_index=True,
+            )
 
     assert not image_metadata.empty, "the image data frame is empty"
     spdata = SpatialData(

--- a/pegasusio/views.py
+++ b/pegasusio/views.py
@@ -394,9 +394,15 @@ class UnimodalDataView:
                 self.matrices[key] = X[self.barcode_index][:,self.feature_index] # X[self.barcode_index.reshape(-1, 1), self.feature_index] if self._all_arrays else X[self.barcode_index, self.feature_index]
         return self.matrices
 
-    def copy(self) -> "UnimodalData":
+    def copy(
+        self,
+        to_unidata: bool = False,
+    ) -> Union["MultimodalData", "UnimodalData"]:
         """ After copy, this View object becomes invalid """
         data = self.parent._copy_view(self)
+        if not to_unidata:
+            from pegasusio import MultimodalData
+            data = MultimodalData(data)
 
         self.parent = None
         self.barcode_index = self.feature_index = None


### PR DESCRIPTION
## Fix 1

The `copy()` function of `UnimodalDataView` now returns a MultimodalData object by default (previously UnimodalData), with an option `to_unidata` if users still want a UnimodalData object.

## Fix 2

`pd.concat` emits the following warning:

>The behavior of DataFrame concatenation with empty or all-NA entries is deprecated. In a future version, this will no longer exclude empty or all-NA columns when determining the result dtypes. To retain the old behavior, exclude the relevant entries before the concat operation 

when it concatenates at least one empty DataFrame. So add an justifier and explicitly set `None` for empty DataFrame objects.