### PR TITLE
Fix pandas v3

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -507,7 +507,7 @@ class UnimodalData:
         except ModuleNotFoundError:
             print("No module named 'pegasusio.cylib.funcs'")
 
-        barcodes, channels = split_barcode_channel(self.barcode_metadata.index.values)
+        barcodes, channels = split_barcode_channel(self.barcode_metadata.index.to_numpy(dtype=object))   # Need explicit conversion to object dtype in pandas v3
 
         if np.unique(channels).size > 1:
             # we have multiple channels

--- a/setup.py
+++ b/setup.py
@@ -34,10 +34,11 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
+        "Programming Language :: Python :: 3.14",
         "Topic :: Software Development :: Build Tools",
         "Topic :: Scientific/Engineering :: Bio-Informatics",
     ],
@@ -48,6 +49,6 @@ setup(
     install_requires=[
         l.strip() for l in Path("requirements.txt").read_text("utf-8").splitlines()
     ],
-    python_requires="~=3.8",
+    python_requires="~=3.10",
     entry_points={"console_scripts": ["pegasusio=pegasusio.__main__:main"]},
 )


### PR DESCRIPTION
In Pandas v3, the cython function `split_barcode_channel` encounters the following error:
```
TypeError: a bytes-like object is required, not 'StringArray'
```
with type signature
```
cpdef tuple split_barcode_channel(str[:] arr):
```

This is because in pandas v2 strings are typically stored in NumPy arrays with the `object` dtype (i.e. bytes-like object), while in v3 they become pandas' own Arrow-backed `StringArray` type.

**Solution:** Since Cython does not support pandas `StringArray`, the only fix is to explicitly convert the pandas Series of `str` dtype into `object` dtype. Another benefit is that this fix is compatible to both pandas v2 and v3.

