### PR TITLE
Zarr 3 support + AnnData support

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    name: ${{ matrix.os }}, Python ${{ matrix.python-version }}, zarr v${{ matrix.zarr_version }}
 
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
+        python-version: ['3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -15,10 +15,14 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python-version: ['3.11', '3.12', '3.13', '3.14']
+        zarr_version: ['3', '2']
+        exclude:
+          - python-version: '3.11'
+            zarr_version: '3'
 
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python ${{ matrix.python-version }} with zarr ${{ matrix.zarr_version }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
@@ -26,6 +30,11 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest setuptools wheel anndata
+        if [[ "${{ matrix.zarr_version }}" == "3" ]]; then
+          python -m pip install "zarr>=3.1,<4"
+        else
+          python -m pip install "zarr>=2.18.7,<3"
+        fi
         python -m pip install -e .
     - name: Lint with flake8
       run: |
@@ -38,7 +47,7 @@ jobs:
         git clone https://github.com/lilab-bcb/pegasusio-test-data.git ./pegasusio-test-data
     - name: IO test
       run: |
-        pytest tests/test_io.py
+        pytest tests/test_io.py tests/test_anndata.py tests/test_zarr.py
     - name: Data aggregation test
       run: |
         bash tests/run_aggregate_matrix.sh

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -30,11 +30,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest setuptools wheel anndata
+        python -m pip install flake8 pytest setuptools wheel
         if [[ "${{ matrix.zarr_version }}" == "3" ]]; then
-          python -m pip install "zarr>=3.1,<4"
+          python -m pip install "zarr>=3.1,<4" anndata
         else
-          python -m pip install "zarr>=2.18.7,<3"
+          python -m pip install "zarr>=2.18.7,<3" "anndata<0.13"
         fi
         python -m pip install -e .
     - name: Lint with flake8

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        python-version: [ '3.11', '3.12', '3.13', '3.14']
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14']
 
     steps:
     - uses: actions/checkout@v2

--- a/pegasusio/hdf5_utils.py
+++ b/pegasusio/hdf5_utils.py
@@ -362,9 +362,16 @@ def write_loom_file(data: MultimodalData, output_file: str) -> None:
     def _process_attrs(
         key_name: str, attrs: pd.DataFrame, attrs_multi: dict
     ) -> Dict[str, object]:
-        res_dict = {key_name: attrs.index.values}
+        def _as_ndarray(values, dtype=None) -> np.ndarray:
+            if hasattr(values, "to_numpy"):
+                values = values.to_numpy(dtype=dtype)
+            elif not isinstance(values, np.ndarray):
+                values = np.asarray(values, dtype=dtype)
+            return values if isinstance(values, np.ndarray) else np.asarray(values, dtype=dtype)
+
+        res_dict = {key_name: _as_ndarray(attrs.index, dtype=object)}
         for key in attrs.columns:
-            res_dict[_replace_slash(key)] = np.array(attrs[key].values)
+            res_dict[_replace_slash(key)] = _as_ndarray(attrs[key])
         for key, value in attrs_multi.items():
             if (
                 value.ndim > 1

--- a/pegasusio/qc_utils.py
+++ b/pegasusio/qc_utils.py
@@ -1,8 +1,6 @@
 import numpy as np
 import pandas as pd
 
-from pegasusio import UnimodalData
-
 import logging
 logger = logging.getLogger(__name__)
 
@@ -29,7 +27,7 @@ class DictWithDefault:
 
 
 def calc_qc_filters(
-    unidata: UnimodalData,
+    unidata,
     select_singlets: bool = False,
     remap_string: str = None,
     subset_string: str = None,
@@ -44,7 +42,7 @@ def calc_qc_filters(
 
     Parameters
     ----------
-    unidata: ``UnimodalData``
+    unidata: ``UnimodalData`` or ``anndata.AnnData``
        Unimodal data matrix with rows for cells and columns for genes.
     select_singlets: ``bool``, optional, default ``False``
         If select only singlets.
@@ -81,7 +79,8 @@ def calc_qc_filters(
     --------
     >>> calc_qc_filters(unidata, min_umis = 500, select_singlets = True)
     """
-    assert unidata.uns["modality"] in {"rna", "visium"}
+    if "modality" in unidata.uns:
+        assert unidata.uns["modality"] in {"rna", "visium"}
 
     filters = []
 
@@ -145,7 +144,7 @@ def calc_qc_filters(
         unidata.obs["passed_qc"] = True
 
 
-def apply_qc_filters(unidata: UnimodalData, uns_white_list: str = None):
+def apply_qc_filters(unidata, uns_white_list: str = None):
     """ Apply QC filters to filter out low quality cells """
     if "passed_qc" in unidata.obs:
         prior_n = unidata.shape[0]
@@ -172,4 +171,5 @@ def apply_qc_filters(unidata: UnimodalData, uns_white_list: str = None):
             for key in list(unidata.uns):
                 if key not in white_list:
                     del unidata.uns[key]
-        logger.info(f"After filtration, {unidata.shape[0]} out of {prior_n} cell barcodes are kept in UnimodalData object {unidata.get_uid()}.")
+        uid = unidata.get_uid() if hasattr(unidata, 'get_uid') else ''
+        logger.info(f"After filtration, {unidata.shape[0]} out of {prior_n} cell barcodes are kept in data object {uid}.")

--- a/pegasusio/readwrite.py
+++ b/pegasusio/readwrite.py
@@ -252,7 +252,7 @@ def write_output(
     if file_type.startswith("zarr"):
         zf = ZarrFile(output_file, mode = "w", storage_type = "ZipStore" if file_type == "zarr.zip" else None)
         zf.write_multimodal_data(data)
-        del zf
+        zf.close()
     elif file_type == "h5ad":
         data.to_anndata().write(output_file, compression="gzip")
     elif file_type == "loom":

--- a/pegasusio/unimodal_data.py
+++ b/pegasusio/unimodal_data.py
@@ -628,7 +628,7 @@ class UnimodalData:
             var_cols = []
             if "featureid" in self.feature_metadata:
                 var_cols.append("featureid")
-            raw = anndata.AnnData(X = self.matrices[raw_key], dtype = self.matrices[raw_key].dtype, var = self.feature_metadata[var_cols])
+            raw = anndata.AnnData(X = self.matrices[raw_key], var = self.feature_metadata[var_cols])
 
         layers = {}
         for key, value in self.matrices.items():
@@ -636,7 +636,6 @@ class UnimodalData:
                 layers[key] = value
 
         return anndata.AnnData(X = self.matrices[X_key],
-            dtype = self.matrices[X_key].dtype,
             obs = self.barcode_metadata,
             var = self.feature_metadata,
             uns = self.metadata,

--- a/pegasusio/zarr_utils.py
+++ b/pegasusio/zarr_utils.py
@@ -2,6 +2,8 @@
 
 import os
 import shutil
+import tempfile
+import zipfile
 import PIL
 import numpy as np
 import pandas as pd
@@ -10,6 +12,7 @@ from scipy.sparse import csr_matrix, issparse
 import zarr
 
 from zarr.codecs import BloscCodec
+from zarr.dtype import VariableLengthUTF8
 from zarr.storage import ZipStore, LocalStore
 
 from natsort import natsorted
@@ -57,6 +60,19 @@ def check_and_remove_existing_path(path: str) -> None:
             logger.warning(f"Detected and removed pre-existing file {path}.")
 
 
+def zip_directory(src_path: str, dest_path: str) -> None:
+    with zipfile.ZipFile(dest_path, mode = 'w', compression = zipfile.ZIP_STORED, allowZip64 = True) as zf:
+        for root, _, files in os.walk(src_path):
+            for fname in sorted(files):
+                fpath = os.path.join(root, fname)
+                zf.write(fpath, os.path.relpath(fpath, src_path))
+
+
+def unzip_directory(src_path: str, dest_path: str) -> None:
+    with zipfile.ZipFile(src_path, mode = 'r') as zf:
+        zf.extractall(dest_path)
+
+
 class ZarrFile:
     def __init__(self, path: str, mode: str = 'r', storage_type: str = None) -> None:
         """ Initialize a Zarr file, if mode == 'w', create an empty one, otherwise, load from path
@@ -64,7 +80,8 @@ class ZarrFile:
         storage_type : `str`, currently only support 'ZipStore' and 'LocalStore'. If None, use 'LocalStore' by default.
         """
         self.store = self.root = None
-        self.write_empty_chunks = False
+        self._zip_path = None
+        self._temp_store_path = None
 
         if storage_type is None:
             storage_type = 'LocalStore'
@@ -72,9 +89,13 @@ class ZarrFile:
         if mode == 'w':
             # Create a new zarr file
             check_and_remove_existing_path(path)
-            self.store = ZipStore(path, mode = 'w') if storage_type == 'ZipStore' else LocalStore(path)
+            if storage_type == 'ZipStore':
+                self._zip_path = path
+                self._temp_store_path = tempfile.mkdtemp(prefix = 'pegasusio-zarr-', suffix = '.zarr')
+                self.store = LocalStore(self._temp_store_path)
+            else:
+                self.store = LocalStore(path)
             self.root = zarr.group(self.store, overwrite = True)
-            self.write_empty_chunks = (storage_type == 'ZipStore')
         else:
             # Load existing zarr file
             self.store = LocalStore(path) if os.path.isdir(path) else ZipStore(path, mode = 'r')
@@ -83,29 +104,46 @@ class ZarrFile:
             self.root = zarr.open(self.store, mode = mode)
 
 
-    def __del__(self):
+    def close(self):
         if self.store is not None and hasattr(self.store, 'close'):
-            self.store.close()
+            try:
+                self.store.close()
+            except AttributeError:
+                pass
+        if self._zip_path is not None:
+            zip_directory(self._temp_store_path, self._zip_path)
+            shutil.rmtree(self._temp_store_path)
+            self._zip_path = None
+            self._temp_store_path = None
+        self.store = None
+
+
+    def __del__(self):
+        self.close()
 
 
     def _to_zip(self):
         if not isinstance(self.store, ZipStore):
-            zip_path = self.store.path + '.zip'
-            zip_store = ZipStore(zip_path, mode = 'w')
-            zarr.copy_store(self.store, zip_store)
-            zip_store.close()
+            dir_path = str(self.store.root)
+            zip_path = dir_path + '.zip'
+            check_and_remove_existing_path(zip_path)
+            self.store.close()
 
-            shutil.rmtree(self.store.path)
+            zip_directory(dir_path, zip_path)
+            shutil.rmtree(dir_path)
 
-            self.store = zarr.ZipStore(zip_path, mode = 'r')
+            self.store = ZipStore(zip_path, mode = 'r')
             self.root = zarr.open_group(self.store, mode = 'r')
 
 
     def _to_directory(self):
-        orig_path = self.store.path
+        orig_path = str(self.store.path)
 
         if not orig_path.endswith('.zip'):
-            self.store.close()
+            try:
+                self.store.close()
+            except AttributeError:
+                pass
             zip_path = orig_path + '.zip'
             check_and_remove_existing_path(zip_path)
             os.replace(orig_path, zip_path)
@@ -115,13 +153,15 @@ class ZarrFile:
 
         dest_path = zip_path[:-4]
         check_and_remove_existing_path(dest_path)
-        dir_store = LocalStore(dest_path)
-        zarr.copy_store(self.store, dir_store)
-        self.store.close()
+        try:
+            self.store.close()
+        except AttributeError:
+            pass
+        unzip_directory(zip_path, dest_path)
         os.remove(zip_path)
 
-        self.store = dir_store
-        self.root = zarr.open_group(self.store)
+        self.store = LocalStore(dest_path)
+        self.root = zarr.open_group(self.store, mode = 'a')
 
         logger.info(f"Converted ZipStore zarr file {orig_path} to LocalStore {dest_path}.")
 
@@ -133,7 +173,7 @@ class ZarrFile:
             # categorical column
             return pd.Categorical.from_codes(group[name][...], categories = group[f'_categories/{name}'][...], ordered = group[name].attrs['ordered'])
         else:
-            if isinstance(group[name], zarr.hierarchy.Group):
+            if isinstance(group[name], zarr.Group):
                 ll = []
                 for data in group[name].arrays():
                     ll.append(PIL.Image.fromarray(data[1][...]))
@@ -287,9 +327,9 @@ class ZarrFile:
     def write_csr(self, parent: zarr.Group, name: str, matrix: csr_matrix) -> None:
         group = parent.create_group(name, overwrite = True)
         group.attrs.update(data_type = 'csr_matrix', shape = matrix.shape)
-        group.create_dataset('data', data = matrix.data, shape = matrix.data.shape, chunks = calc_chunk(matrix.data.shape), dtype = matrix.data.dtype, compressor = COMPRESSOR, overwrite = True, write_empty_chunks = self.write_empty_chunks)
-        group.create_dataset('indices', data = matrix.indices, shape = matrix.indices.shape, chunks = calc_chunk(matrix.indices.shape), dtype = matrix.indices.dtype, compressor = COMPRESSOR, overwrite = True, write_empty_chunks = self.write_empty_chunks)
-        group.create_dataset('indptr', data = matrix.indptr, shape = matrix.indptr.shape, chunks = calc_chunk(matrix.indptr.shape), dtype = matrix.indptr.dtype, compressor = COMPRESSOR, overwrite = True, write_empty_chunks = self.write_empty_chunks)
+        self.write_array(group, 'data', matrix.data)
+        self.write_array(group, 'indices', matrix.indices)
+        self.write_array(group, 'indptr', matrix.indptr)
 
 
     def write_series(self, group: zarr.Group, name: str, array: np.ndarray) -> None:
@@ -306,7 +346,7 @@ class ZarrFile:
                 values = np.array([x.decode() for x in values], dtype = object)
             self.write_array(categories, name, values)
             # write codes
-            codes_arr = group.create_dataset(name, data = array.codes, shape = array.codes.shape, chunks = calc_chunk(array.codes.shape), dtype = array.codes.dtype, compressor = COMPRESSOR, overwrite = True, write_empty_chunks = self.write_empty_chunks)
+            codes_arr = self.write_array(group, name, array.codes)
             codes_arr.attrs['ordered'] = bool(array.ordered)
         else:
             self.write_array(group, name, array)
@@ -328,9 +368,16 @@ class ZarrFile:
                 self.write_series(group, col, df[col].values)
         group.attrs.update(**attrs_dict)
 
-    def write_array(self, group: zarr.Group, name: str, array: np.ndarray) -> None:
-        dtype = str if array.dtype.kind == 'O' else array.dtype
-        group.create_dataset(name, data = array, shape = array.shape, chunks = calc_chunk(array.shape), dtype = dtype, compressor = COMPRESSOR, overwrite = True, write_empty_chunks = self.write_empty_chunks)
+    def write_array(self, group: zarr.Group, name: str, array: np.ndarray) -> zarr.Array:
+        array = np.asarray(array)
+        if array.dtype.kind in {'O', 'U', 'S'}:
+            dtype = VariableLengthUTF8()
+            array = array.astype(str)
+        else:
+            dtype = array.dtype
+        zarr_array = group.create_array(name, shape = array.shape, chunks = calc_chunk(array.shape), dtype = dtype, compressors = [COMPRESSOR], overwrite = True)
+        zarr_array[...] = array
+        return zarr_array
 
     def write_record_array(self, parent: zarr.Group, name: str, array: np.recarray) -> None:
         group = parent.create_group(name, overwrite = True)

--- a/pegasusio/zarr_utils.py
+++ b/pegasusio/zarr_utils.py
@@ -11,9 +11,23 @@ from pandas.api.types import is_categorical_dtype, is_string_dtype, is_scalar, i
 from scipy.sparse import csr_matrix, issparse
 import zarr
 
-from zarr.codecs import BloscCodec
-from zarr.dtype import VariableLengthUTF8
-from zarr.storage import ZipStore, LocalStore
+ZARR_V3 = int(zarr.__version__.split('.')[0]) >= 3
+
+if ZARR_V3:
+    from zarr.codecs import BloscCodec
+    from zarr.dtype import VariableLengthUTF8
+    from zarr.storage import ZipStore, LocalStore
+
+    DirectoryStore = LocalStore
+    COMPRESSOR = BloscCodec(cname = 'lz4', clevel = 5)
+else:
+    from zarr import Blosc
+    from zarr.storage import ZipStore, DirectoryStore as ZarrDirectoryStore
+
+    def DirectoryStore(path: str):
+        return ZarrDirectoryStore(path, dimension_separator = '/')
+
+    COMPRESSOR = Blosc(cname = 'lz4', clevel = 5)
 
 from natsort import natsorted
 from typing import Union
@@ -26,7 +40,6 @@ from pegasusio import UnimodalData, VDJData, CITESeqData, CytoData, MultimodalDa
 
 
 CHUNKSIZE = 1000000.0
-COMPRESSOR = BloscCodec(cname = 'lz4', clevel = 5)
 
 
 def calc_chunk(shape: tuple) -> tuple:
@@ -73,18 +86,24 @@ def unzip_directory(src_path: str, dest_path: str) -> None:
         zf.extractall(dest_path)
 
 
+def get_store_path(store) -> str:
+    root = getattr(store, 'root', None)
+    return str(root if root is not None else store.path)
+
+
 class ZarrFile:
     def __init__(self, path: str, mode: str = 'r', storage_type: str = None) -> None:
         """ Initialize a Zarr file, if mode == 'w', create an empty one, otherwise, load from path
         path : `str`, path for the zarr object.
-        storage_type : `str`, currently only support 'ZipStore' and 'LocalStore'. If None, use 'LocalStore' by default.
+        storage_type : `str`, currently only support 'ZipStore' and the default directory store.
         """
         self.store = self.root = None
+        self.write_empty_chunks = False
         self._zip_path = None
         self._temp_store_path = None
 
         if storage_type is None:
-            storage_type = 'LocalStore'
+            storage_type = 'LocalStore' if ZARR_V3 else 'DirectoryStore'
 
         if mode == 'w':
             # Create a new zarr file
@@ -92,13 +111,14 @@ class ZarrFile:
             if storage_type == 'ZipStore':
                 self._zip_path = path
                 self._temp_store_path = tempfile.mkdtemp(prefix = 'pegasusio-zarr-', suffix = '.zarr')
-                self.store = LocalStore(self._temp_store_path)
+                self.store = DirectoryStore(self._temp_store_path)
+                self.write_empty_chunks = True
             else:
-                self.store = LocalStore(path)
+                self.store = DirectoryStore(path)
             self.root = zarr.group(self.store, overwrite = True)
         else:
             # Load existing zarr file
-            self.store = LocalStore(path) if os.path.isdir(path) else ZipStore(path, mode = 'r')
+            self.store = DirectoryStore(path) if os.path.isdir(path) else ZipStore(path, mode = 'r')
             if mode == 'a' and isinstance(self.store, ZipStore):
                 self._to_directory()
             self.root = zarr.open(self.store, mode = mode)
@@ -124,7 +144,7 @@ class ZarrFile:
 
     def _to_zip(self):
         if not isinstance(self.store, ZipStore):
-            dir_path = str(self.store.root)
+            dir_path = get_store_path(self.store)
             zip_path = dir_path + '.zip'
             check_and_remove_existing_path(zip_path)
             self.store.close()
@@ -160,10 +180,10 @@ class ZarrFile:
         unzip_directory(zip_path, dest_path)
         os.remove(zip_path)
 
-        self.store = LocalStore(dest_path)
+        self.store = DirectoryStore(dest_path)
         self.root = zarr.open_group(self.store, mode = 'a')
 
-        logger.info(f"Converted ZipStore zarr file {orig_path} to LocalStore {dest_path}.")
+        logger.info(f"Converted ZipStore zarr file {orig_path} to directory store {dest_path}.")
 
     def read_csr(self, group: zarr.Group) -> csr_matrix:
         return csr_matrix((group['data'][...], group['indices'][...], group['indptr'][...]), shape = group.attrs['shape'])
@@ -370,13 +390,17 @@ class ZarrFile:
 
     def write_array(self, group: zarr.Group, name: str, array: np.ndarray) -> zarr.Array:
         array = np.asarray(array)
-        if array.dtype.kind in {'O', 'U', 'S'}:
-            dtype = VariableLengthUTF8()
-            array = array.astype(str)
+        if ZARR_V3:
+            if array.dtype.kind in {'O', 'U', 'S'}:
+                dtype = VariableLengthUTF8()
+                array = array.astype(str)
+            else:
+                dtype = array.dtype
+            zarr_array = group.create_array(name, shape = array.shape, chunks = calc_chunk(array.shape), dtype = dtype, compressors = [COMPRESSOR], overwrite = True)
+            zarr_array[...] = array
         else:
-            dtype = array.dtype
-        zarr_array = group.create_array(name, shape = array.shape, chunks = calc_chunk(array.shape), dtype = dtype, compressors = [COMPRESSOR], overwrite = True)
-        zarr_array[...] = array
+            dtype = str if array.dtype.kind == 'O' else array.dtype
+            zarr_array = group.create_dataset(name, data = array, shape = array.shape, chunks = calc_chunk(array.shape), dtype = dtype, compressor = COMPRESSOR, overwrite = True, write_empty_chunks = self.write_empty_chunks)
         return zarr_array
 
     def write_record_array(self, parent: zarr.Group, name: str, array: np.recarray) -> None:

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ numpy>=2.0.0
 pandas>=1.2.0
 scipy
 setuptools
-zarr<=2.18.7
+zarr>=3.1.3
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ numpy>=2.0.0
 pandas>=1.2.0
 scipy
 setuptools
-zarr>=3.1
+zarr>=2.18.7,!=3.0.*,<4
 Pillow

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,5 @@ numpy>=2.0.0
 pandas>=1.2.0
 scipy
 setuptools
-zarr>=3.1.3
+zarr>=3.1
 Pillow

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
@@ -48,6 +49,6 @@ setup(
     install_requires=[
         l.strip() for l in Path("requirements.txt").read_text("utf-8").splitlines()
     ],
-    python_requires="~=3.11",
+    python_requires="~=3.10",
     entry_points={"console_scripts": ["pegasusio=pegasusio.__main__:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,6 @@ setup(
         "Operating System :: MacOS :: MacOS X",
         "Operating System :: POSIX :: Linux",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
         "Programming Language :: Python :: 3.13",
@@ -49,6 +48,6 @@ setup(
     install_requires=[
         l.strip() for l in Path("requirements.txt").read_text("utf-8").splitlines()
     ],
-    python_requires="~=3.10",
+    python_requires="~=3.11",
     entry_points={"console_scripts": ["pegasusio=pegasusio.__main__:main"]},
 )

--- a/tests/test_anndata.py
+++ b/tests/test_anndata.py
@@ -1,0 +1,117 @@
+import unittest
+
+import anndata
+import numpy as np
+import pandas as pd
+from scipy.sparse import csr_matrix
+
+import pegasusio as io
+
+
+class TestAnnData(unittest.TestCase):
+
+    def test_calc_qc_filters_with_anndata_input(self):
+        adata = anndata.AnnData(
+            X=csr_matrix(
+                np.array(
+                    [
+                        [1, 0, 2],
+                        [0, 0, 0],
+                        [5, 1, 0],
+                        [2, 2, 1],
+                    ],
+                    dtype=np.float32,
+                )
+            ),
+            obs=pd.DataFrame(
+                {
+                    "demux_type": pd.Categorical(["singlet", "doublet", "singlet", "singlet"]),
+                    "assignment": pd.Categorical(["sample1", "sample2", "sample1", "sample3"]),
+                },
+                index=pd.Index(["cell1", "cell2", "cell3", "cell4"], name="barcodekey"),
+            ),
+            var=pd.DataFrame(
+                index=pd.Index(["MT-ND1", "GeneA", "GeneB"], name="featurekey")
+            ),
+            uns={"modality": "rna"},
+        )
+
+        io.calc_qc_filters(
+            adata,
+            select_singlets=True,
+            min_genes=2,
+            min_umis=3,
+            mito_prefix="MT-",
+            percent_mito=60.0,
+        )
+
+        np.testing.assert_array_equal(adata.obs["n_genes"].values, [2, 0, 2, 3])
+        np.testing.assert_array_equal(adata.obs["n_counts"].values, [3, 0, 6, 5])
+        np.testing.assert_allclose(
+            adata.obs.loc[["cell1", "cell3"], "percent_mito"].values,
+            np.array([100.0 / 3.0, 500.0 / 6.0]),
+            rtol=1e-6,
+        )
+        np.testing.assert_array_equal(
+            adata.obs["passed_qc"].values,
+            np.array([True, False, False, True]),
+        )
+
+    def test_unimodal_data_anndata_roundtrip(self):
+        obs = pd.DataFrame(
+            {
+                "sample": pd.Categorical(["sample1", "sample2", "sample1"]),
+                "n_counts": [3, 4, 7],
+            },
+            index=pd.Index(["cell1", "cell2", "cell3"], name="barcodekey"),
+        )
+        var = pd.DataFrame(
+            {
+                "featureid": ["ENSG1", "ENSG2"],
+                "featuretype": pd.Categorical(["Gene Expression", "Gene Expression"]),
+            },
+            index=pd.Index(["GeneA", "GeneB"], name="featurekey"),
+        )
+        X = csr_matrix(np.array([[1, 0], [0, 2], [3, 4]], dtype=np.float32))
+        counts = csr_matrix(np.array([[2, 0], [0, 3], [4, 5]], dtype=np.float32))
+        pca = np.array([[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]], dtype=np.float32)
+        loadings = np.array([[0.7, 0.8], [0.9, 1.0]], dtype=np.float32)
+        neighbors = csr_matrix(np.array([[1, 1, 0], [1, 1, 1], [0, 1, 1]], dtype=np.float32))
+
+        unidata = io.UnimodalData(
+            obs.copy(),
+            var.copy(),
+            {"X": X, "counts": counts},
+            {"genome": "GRCh38", "modality": "rna", "uid": "GRCh38-rna", "pipeline": "test"},
+            barcode_multiarrays={"X_pca": pca},
+            feature_multiarrays={"PCs": loadings},
+            barcode_multigraphs={"connectivities": neighbors},
+            cur_matrix="X",
+        )
+
+        adata = unidata.to_anndata()
+        roundtrip = io.UnimodalData(adata)
+
+        self.assertEqual(adata.shape, unidata.shape)
+        np.testing.assert_array_equal(adata.X.toarray(), X.toarray())
+        np.testing.assert_array_equal(adata.layers["counts"].toarray(), counts.toarray())
+        np.testing.assert_array_equal(adata.obsm["X_pca"], pca)
+        np.testing.assert_array_equal(adata.varm["PCs"], loadings)
+        np.testing.assert_array_equal(adata.obsp["connectivities"].toarray(), neighbors.toarray())
+
+        self.assertEqual(roundtrip.shape, unidata.shape)
+        self.assertEqual(roundtrip.get_genome(), "GRCh38")
+        self.assertEqual(roundtrip.get_modality(), "rna")
+        self.assertEqual(roundtrip.get_uid(), "GRCh38-rna")
+        self.assertEqual(roundtrip.metadata["pipeline"], "test")
+        pd.testing.assert_frame_equal(roundtrip.obs, obs)
+        pd.testing.assert_frame_equal(roundtrip.var, var)
+        np.testing.assert_array_equal(roundtrip.X.toarray(), X.toarray())
+        np.testing.assert_array_equal(roundtrip.matrices["counts"].toarray(), counts.toarray())
+        np.testing.assert_array_equal(roundtrip.obsm["X_pca"], pca)
+        np.testing.assert_array_equal(roundtrip.varm["PCs"], loadings)
+        np.testing.assert_array_equal(roundtrip.obsp["connectivities"].toarray(), neighbors.toarray())
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/test_zarr.py
+++ b/tests/test_zarr.py
@@ -1,0 +1,141 @@
+import os
+import tempfile
+import unittest
+import zipfile
+from collections import Counter
+
+import numpy as np
+import pandas as pd
+from scipy.sparse import csr_matrix
+
+import pegasusio as io
+
+
+def _make_unimodal_data():
+    obs = pd.DataFrame(
+        {
+            "Channel": pd.Categorical(["channel1", "channel2", "channel1"]),
+            "n_counts": np.array([3, 4, 9], dtype=np.int64),
+        },
+        index=pd.Index(["cell1", "cell2", "cell3"], dtype=object, name="barcodekey"),
+    )
+    var = pd.DataFrame(
+        {
+            "featureid": ["ENSG1", "ENSG2", "ENSG3"],
+            "featuretype": pd.Categorical(
+                ["Gene Expression", "Gene Expression", "Gene Expression"]
+            ),
+        },
+        index=pd.Index(["GeneA", "GeneB", "GeneC"], dtype=object, name="featurekey"),
+    )
+    X = csr_matrix(
+        np.array(
+            [
+                [1, 0, 2],
+                [0, 3, 1],
+                [4, 0, 5],
+            ],
+            dtype=np.float32,
+        )
+    )
+    counts = csr_matrix(
+        np.array(
+            [
+                [2, 0, 3],
+                [0, 4, 1],
+                [5, 0, 6],
+            ],
+            dtype=np.float32,
+        )
+    )
+    umap = np.array([[0.1, 1.1], [0.2, 1.2], [0.3, 1.3]], dtype=np.float32)
+    loadings = np.array(
+        [[0.4, 1.4], [0.5, 1.5], [0.6, 1.6]], dtype=np.float32
+    )
+    connectivities = csr_matrix(
+        np.array(
+            [
+                [1, 1, 0],
+                [1, 1, 1],
+                [0, 1, 1],
+            ],
+            dtype=np.float32,
+        )
+    )
+
+    return io.UnimodalData(
+        obs,
+        var,
+        {"X": X, "counts": counts},
+        {
+            "genome": "GRCh38",
+            "modality": "rna",
+            "uid": "GRCh38-rna",
+            "source": "zarr-zip-test",
+        },
+        barcode_multiarrays={"X_umap": umap},
+        feature_multiarrays={"PCs": loadings},
+        barcode_multigraphs={"connectivities": connectivities},
+        cur_matrix="X",
+    )
+
+
+class TestZarrZip(unittest.TestCase):
+
+    def _assert_roundtrip_equal(self, data, expected):
+        unidata = data.current_data()
+
+        self.assertEqual(data.current_key(), "GRCh38-rna")
+        self.assertEqual(unidata.shape, expected.shape)
+        self.assertEqual(unidata.get_genome(), "GRCh38")
+        self.assertEqual(unidata.get_modality(), "rna")
+        self.assertEqual(unidata.get_uid(), "GRCh38-rna")
+        self.assertEqual(unidata.metadata["source"], "zarr-zip-test")
+        pd.testing.assert_frame_equal(unidata.obs, expected.obs, check_dtype=False)
+        pd.testing.assert_frame_equal(unidata.var, expected.var, check_dtype=False)
+        np.testing.assert_array_equal(unidata.X.toarray(), expected.X.toarray())
+        np.testing.assert_array_equal(
+            unidata.matrices["counts"].toarray(),
+            expected.matrices["counts"].toarray(),
+        )
+        np.testing.assert_array_equal(unidata.obsm["X_umap"], expected.obsm["X_umap"])
+        np.testing.assert_array_equal(unidata.varm["PCs"], expected.varm["PCs"])
+        np.testing.assert_array_equal(
+            unidata.obsp["connectivities"].toarray(),
+            expected.obsp["connectivities"].toarray(),
+        )
+
+    def test_read_zarr_zip(self):
+        expected = _make_unimodal_data()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "input.zarr.zip")
+            io.write_output(expected, path)
+
+            data = io.read_input(path)
+
+        self._assert_roundtrip_equal(data, expected)
+
+    def test_write_zarr_zip(self):
+        expected = _make_unimodal_data()
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            path = os.path.join(tmpdir, "output.zarr.zip")
+            io.write_output(expected, path)
+
+            self.assertTrue(zipfile.is_zipfile(path))
+            with zipfile.ZipFile(path, mode="r") as zf:
+                names = zf.namelist()
+            duplicated = [name for name, count in Counter(names).items() if count > 1]
+            self.assertEqual(duplicated, [])
+            self.assertTrue(
+                any(name.endswith(".zgroup") or name.endswith("zarr.json") for name in names)
+            )
+
+            data = io.read_input(path)
+
+        self._assert_roundtrip_equal(data, expected)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
* `read_input`:
  * Minor changes. Mainly to adapt for zarr v3 API.
* `write_output`:
  * No longer directly opening a `ZipStore`. Instead, create a temporary `LocalStore` directory, and when `close()`, zip it using `zip_directory()` helper and clean up the temp dir.
  * Directly operating on `ZipStore` when `create_group(..., overwrite=True)` cannot remove old entries from the zip but duplicates. Thus a number of `UserWarning: Duplicate name` warnings will be emitted and file size would be large.
* `qc_utils.py`:
  * Support `AnnData` type in `calc_qc_filters` and `apply_qc_filters` functions.
* Drop python 3.10 support, because zarr v3 only support python 3.11+.
* Add more CI tests:
  * Test for Zarr v2 and v3 respectively.
  * Add tests for running `calc_qc_filters` on AnnData objects, as well as roundtrip between UnimodalData and AnnData objects (`tests/test_anndata.py`)
  * Add tests for read and write on `.zarr.zip` files. (`tests/test_zarr.py`)
 
Other misc updates:
* Remove `dtype` in `AnnData` as it's obsolete since anndata v0.13.
* Convert `pandas.StringArray` to `numpy.Array` when saving to `.loom` file.