### PR TITLE
Update Blosc import

### DIFF
--- a/pegasusio/zarr_utils.py
+++ b/pegasusio/zarr_utils.py
@@ -9,7 +9,8 @@ from pandas.api.types import is_categorical_dtype, is_string_dtype, is_scalar, i
 from scipy.sparse import csr_matrix, issparse
 import zarr
 
-from zarr import Blosc, ZipStore, NestedDirectoryStore
+from zarr import ZipStore, NestedDirectoryStore
+from numcodecs import Blosc
 
 from natsort import natsorted
 from typing import Union


### PR DESCRIPTION
Hello,

The latest version of zarr / numcodecs seems to have changed their API, and they no longer export blosc:

```
:43.6487772Z   File "/home/runner/work/_temp/Library/reticulate/python/rpytools/loader.py", line 120, in _hook
2026-07-10T13:25:43.6488276Z     return _find_and_load(name, import_)
2026-07-10T13:25:43.6488591Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2026-07-10T13:25:43.6489166Z   File "/home/runner/.local/lib/python3.12/site-packages/pegasusio/zarr_utils.py", line 11, in <module>
2026-07-10T13:25:43.6489904Z     from zarr import Blosc
2026-07-10T13:25:43.6490671Z ImportError: cannot import name 'Blosc' from 'zarr' (/home/runner/.local/lib/python3.12/site-packages/zarr/__init__.py)
```

Switching to import from numcodecs seems to fix the issue